### PR TITLE
Continuous Tweet Collection

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -165,6 +165,7 @@ ORDER BY 1 DESC
 
 <hr>
 
+
 ## Friend Lookups
 
 Friend lookups script:
@@ -280,6 +281,26 @@ FROM `tweet-collector-py.disinfo_2021_production.followers`
 GROUP BY 1
 ORDER BY 1 DESC
 ```
+
+## Continuous Tweet Collection
+
+Users with successful timeline lookups:
+
+```sql
+SELECT
+  user_id
+  ,count(distinct status_id) as status_count
+  ,max(status_id) as latest_status
+  --,extract(date from min(created_at)) as earliest_on
+  --,extract(date from max(created_at)) as latest_on
+  ,extract(date from max(lookup_at)) as latest_lookup
+FROM `tweet-collector-py.disinfo_2021_production.timeline_tweets`
+GROUP BY 1
+ORDER BY 4
+```
+
+
+
 
 ## Downstream Views (Analysis Environment)
 

--- a/Procfile
+++ b/Procfile
@@ -5,3 +5,4 @@ user_lookups: python -m app.jobs.user_lookups
 timeline_lookups: python -m app.jobs.timeline_lookups
 friend_lookups: python -m app.jobs.friend_lookups
 follower_lookups: python -m app.jobs.follower_lookups
+timeline_collection: python -m app.jobs.timeline_collection

--- a/README.md
+++ b/README.md
@@ -103,6 +103,14 @@ Lookup followers, specifying the max number of users to fetch, and the max numbe
 USER_LIMIT=100 FOLLOWER_LIMIT=10_000 python -m app.jobs.follower_lookups
 ```
 
+
+Continuous collection of tweet timelines, specifying the max number of users to fetch, and the max number of tweets per user (it also uses their last tweet id if we have it):
+
+```sh
+USER_LIMIT=3 STATUS_LIMIT=5_000 python -m app.jobs.timeline_collection
+```
+
+
 ## Testing
 
 Run tests:

--- a/app/jobs/timeline_collection.py
+++ b/app/jobs/timeline_collection.py
@@ -14,7 +14,7 @@ from app.tweet_parser import parse_timeline_status
 load_dotenv()
 
 USER_LIMIT = os.getenv("USER_LIMIT", default="100_000")
-STATUS_LIMIT = os.getenv("STATUS_LIMIT", default="10_000")
+STATUS_LIMIT = os.getenv("STATUS_LIMIT", default="100_000")
 
 
 class TimelineCollectionJob():

--- a/app/jobs/timeline_collection.py
+++ b/app/jobs/timeline_collection.py
@@ -6,7 +6,7 @@ from functools import lru_cache
 from dotenv import load_dotenv
 #from tqdm import tqdm as progress_bar
 
-from app import seek_confirmation
+from app import seek_confirmation, APP_ENV
 from app.bq_service import BigQueryService, generate_timestamp
 from app.twitter_service import TwitterService
 from app.tweet_parser import parse_timeline_status
@@ -166,5 +166,9 @@ if __name__ == '__main__':
             if errors:
                 pprint(errors)
                 #breakpoint()
+
+    if APP_ENV == "production":
+        print("SLEEPING...")
+        sleep(3 * 24 * 60 * 60) # let the server rest while we have time to shut it down
 
     print("JOB COMPLETE!")

--- a/app/jobs/timeline_collection.py
+++ b/app/jobs/timeline_collection.py
@@ -167,8 +167,8 @@ if __name__ == '__main__':
                 pprint(errors)
                 #breakpoint()
 
+    print("JOB COMPLETE!")
+
     if APP_ENV == "production":
         print("SLEEPING...")
         sleep(3 * 24 * 60 * 60) # let the server rest while we have time to shut it down
-
-    print("JOB COMPLETE!")

--- a/app/jobs/timeline_collection.py
+++ b/app/jobs/timeline_collection.py
@@ -13,7 +13,7 @@ from app.tweet_parser import parse_timeline_status
 
 load_dotenv()
 
-USER_LIMIT = os.getenv("USER_LIMIT", default="250")
+USER_LIMIT = os.getenv("USER_LIMIT", default="100_000")
 STATUS_LIMIT = os.getenv("STATUS_LIMIT", default="10_000")
 
 

--- a/app/tweet_parser.py
+++ b/app/tweet_parser.py
@@ -26,7 +26,7 @@ def parse_timeline_status(status):
         "status_text": parse_string(parse_full_text(status)),
         "created_at": generate_timestamp(status.created_at),
 
-        "geo": status.geo,
+        "geo": str(status.geo), # think this is a nested object
         "is_quote": status.is_quote_status,
         "truncated": status.truncated,
 


### PR DESCRIPTION
Setup continuous tweet collection for the disinformation users.

We should be able to run the collection script once per day or once per week. For each active user, It should fetch all the tweets more recent than the most recent tweet we have collected.

We can store the tweets in the existing timelines table and the lookups in the existing timeline lookups table, as long as that won't bring about a conflict if we need to run the timeline script again. Otherwise we can set up a new lookups and tweets table for this separate process (might be a cleaner solution). 